### PR TITLE
audioop was deprecated (3.11) and removed (3.13) from python std lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,8 @@ requirements = [
     "jinja2",
     "ipywidgets",
     "pillow",
-    "psutil"
+    "psutil",
+    "audioop-lts"
 ]
 
 test_requirements = []


### PR DESCRIPTION
not sure if anyone is on the other end here, but just a tiny fix.

