### PR TITLE
if message level is passed as int, convert it to MessageLevel

### DIFF
--- a/yuuno_ipython/ipy_vs/log.py
+++ b/yuuno_ipython/ipy_vs/log.py
@@ -58,6 +58,13 @@ class LogMessage(object):
 class LogWriterFeature(VSFeature):
 
     def _push_log_msg(self, level: MessageLevel, msg: str) -> None:
+        if not isinstance(level, MessageLevel):
+            try:
+                level = MessageLevel(level)
+            except ValueError:
+                # Handle unknown level, e.g. default or raise
+                level = MessageLevel.mtInfo
+
         level = level.value
 
         if level == MessageLevel.mtDebug:


### PR DESCRIPTION
sometimes MessageLevels were getting passed as int instead of MessageLevel. this is a bit ugly and has some smell to it because ideally we'd want to find the source. I noticed the error when I had mismatched vapoursynth versions between core and python, but I wasn't able to locate that check in the yuuno codebase.